### PR TITLE
Add graph-kubernetes helm chart

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,21 @@
+name: gitleaks
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code repository source code
+        uses: actions/checkout@v2
+
+      - name: gitleaks-action
+        uses: zricethezav/gitleaks-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release Chart
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Chart dependencies
+/charts/*/charts

--- a/charts/graph-kubernetes/.gitignore
+++ b/charts/graph-kubernetes/.gitignore
@@ -1,0 +1,2 @@
+requirements.lock
+Chart.lock

--- a/charts/graph-kubernetes/.helmignore
+++ b/charts/graph-kubernetes/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: graph-kubernetes
+description:
+  Converts K8s resources into a graph model for ingestion into JupiterOne.
+type: application
+version: 0.1.0
+appVersion: '0.1.0'

--- a/charts/graph-kubernetes/README.md
+++ b/charts/graph-kubernetes/README.md
@@ -1,0 +1,81 @@
+# JupiterOne Graph Kubernetes
+
+This chart bootstraps a
+[graph-kubernetes](https://github.com/JupiterOne/graph-kubernetes) deployment on
+a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
+package manager.
+
+## Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3+
+
+## Quickstart
+
+If you're ok with the defaults and just want to set your account specific
+information run the following commands with your account information:
+
+```console
+helm repo add jupiterone https://jupiterone.github.io/helm-charts
+helm repo update
+helm install [RELEASE_NAME] jupiterone/graph-kubernetes --set secrets.jupiteroneAccountId="some-account-id" --set secrets.jupiteroneApiKey="some-api-key" --set secrets.jupiteroneIntegrationInstanceId="some-integration-instance-id"
+```
+
+## Get Repo Info
+
+```console
+helm repo add jupiterone https://jupiterone.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command
+documentation._
+
+## Install Chart
+
+```console
+$ helm install [RELEASE_NAME] jupiterone/graph-kubernetes
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command
+documentation._
+
+## Uninstall Chart
+
+```console
+$ helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes
+the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command
+documentation._
+
+## Upgrading Chart
+
+```console
+$ helm upgrade [RELEASE_NAME] jupiterone/graph-kubernetes --install
+```
+
+## Configuration
+
+See
+[Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
+To see all configurable options with detailed comments, visit the chart's
+[values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+$ helm show values jupiterone/graph-kubernetes
+```
+
+### RBAC Configuration
+
+To manually setup RBAC you need to set the parameter `rbac.create=false` and
+specify the service account to be used by setting the parameters:
+`serviceAccount.create` to `false` and `serviceAccount.name` to the name of a
+pre-existing service account.
+
+Roles and RoleBindings resources will be created automatically.

--- a/charts/graph-kubernetes/templates/_helpers.tpl
+++ b/charts/graph-kubernetes/templates/_helpers.tpl
@@ -1,0 +1,96 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "graph-kubernetes.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "graph-kubernetes.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "graph-kubernetes.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "graph-kubernetes.labels" -}}
+helm.sh/chart: {{ include "graph-kubernetes.chart" . }}
+{{ include "graph-kubernetes.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "graph-kubernetes.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "graph-kubernetes.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "graph-kubernetes.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "graph-kubernetes.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the graph-kubernetes.namespace template if set with forceNamespace or .Release.Namespace is set
+https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/_helpers.tpl
+*/}}
+{{- define "graph-kubernetes.namespace" -}}
+{{- if .Values.forceNamespace -}}
+{{ printf "namespace: %s" .Values.forceNamespace }}
+{{- else -}}
+{{ printf "namespace: %s" .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for cronjob.
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1" }}
+{{- print "batch/v1" -}}
+{{- else -}}
+{{- print "batch/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/graph-kubernetes/templates/clusterrole.yaml
+++ b/charts/graph-kubernetes/templates/clusterrole.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.rbac.create .Values.rbac.useClusterRole (not .Values.rbac.useExistingRole) }}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ template "graph-kubernetes.fullname" . }}
+  labels:
+    {{- include "graph-kubernetes.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - ''
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - extensions
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - apps
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - batch
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+{{ end }}

--- a/charts/graph-kubernetes/templates/clusterrolebinding.yaml
+++ b/charts/graph-kubernetes/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.rbac.useClusterRole -}}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "graph-kubernetes.labels" . | nindent 4 }}
+  name: {{ template "graph-kubernetes.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "graph-kubernetes.serviceAccountName" . }}
+{{ include "graph-kubernetes.namespace" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- if (not .Values.rbac.useExistingRole) }}
+  name: {{ template "graph-kubernetes.fullname" . }}
+{{- else }}
+  name: {{ .Values.rbac.useExistingRole }}
+{{- end }}
+{{- end }}

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -1,0 +1,63 @@
+apiVersion: {{ template "cronjob.apiVersion" . }}
+kind: CronJob
+metadata:
+  name: {{ template "graph-kubernetes.fullname" . }}
+spec:
+  schedule: "{{ .Values.cronjob.schedule }}"
+  jobTemplate:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "graph-kubernetes.labels" . | nindent 12 }}
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "graph-kubernetes.serviceAccountName" . }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{ end }}
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: ACCESS_TYPE
+                  value: {{ ternary "cluster" "namespace" .Values.rbac.useClusterRole }} 
+                - name: NAMESPACE
+                  value: {{ .Release.Namespace }}
+                - name: JUPITERONE_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: jupiterone-integration-secret
+                      key: jupiteroneAccountId
+                - name: JUPITERONE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: jupiterone-integration-secret
+                      key: jupiteroneApiKey
+                - name: INTEGRATION_INSTANCE_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: jupiterone-integration-secret
+                      key: jupiteroneIntegrationInstanceId
+                - name: IS_RUNNING_TEST
+                  value: 'false'
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/graph-kubernetes/templates/role.yaml
+++ b/charts/graph-kubernetes/templates/role.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.rbac.create (eq .Values.rbac.useClusterRole false) (not .Values.rbac.useExistingRole) }}
+{{- range $.Values.namespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "graph-kubernetes.fullname" . }}
+  labels:
+    {{- include "graph-kubernetes.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - ''
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - extensions
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - apps
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - batch
+    resources: ['*']
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}
+{{- end }}

--- a/charts/graph-kubernetes/templates/rolebinding.yaml
+++ b/charts/graph-kubernetes/templates/rolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.rbac.create (eq .Values.rbac.useClusterRole false) -}}
+{{ range $.Values.namespaces -}}
+---
+apiVersion: {{ template "rbac.apiVersion" $ }}
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "graph-kubernetes.labels" $ | nindent 4 }}
+  name: {{ template "graph-kubernetes.fullname" $ }}
+  namespace: {{ . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "graph-kubernetes.serviceAccountName" $ }}
+{{ include "graph-kubernetes.namespace" $ | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- if (not $.Values.useExistingRole) }}
+  name: {{ template "graph-kubernetes.fullname" $ }}
+{{- else }}
+  name: {{ $.Values.useExistingRole }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/charts/graph-kubernetes/templates/secret.yaml
+++ b/charts/graph-kubernetes/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "graph-kubernetes.fullname" . }}
+  labels:
+    {{- include "graph-kubernetes.labels" . | nindent 4 }}
+type: Opaque
+data:
+  jupiteroneAccountId: {{ default "" .Values.secrets.jupiteroneAccountId | b64enc | quote }}
+  jupiteroneApiKey: {{ default "" .Values.secrets.jupiteroneApiKey | b64enc | quote }}
+  jupiteroneIntegrationInstanceId: {{ default "" .Values.secrets.jupiteroneIntegrationInstanceId | b64enc | quote }}

--- a/charts/graph-kubernetes/templates/serviceaccount.yaml
+++ b/charts/graph-kubernetes/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "graph-kubernetes.labels" . | nindent 4 }}
+  name: {{ template "graph-kubernetes.serviceAccountName" . }}
+{{ include "graph-kubernetes.namespace" . | indent 2 }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -1,0 +1,102 @@
+################################
+########### General ############
+################################
+image:
+  repository: jupiterone/graph-kubernetes
+  pullPolicy: IfNotPresent
+  tag: "0.1.0"
+
+cronjob:
+  schedule: "*/30 * * * *"
+
+secrets:
+  jupiteroneAccountId:
+  jupiteroneApiKey:
+  jupiteroneIntegrationInstanceId:
+
+## namespaces to ingest (instead of ingesting the entire cluster). Needed if you want to run without Cluster-admin privileges.
+# namespaces:
+#   - yournamespace
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+################################
+######### Scheduling ###########
+################################
+
+### Pod Annotations
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Node labels
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Node tolerations for alertmanager scheduling to nodes with taints
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+##
+tolerations: []
+# - key: "key"
+#   operator: "Equal|Exists"
+#   value: "value"
+#   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+### Node affinity
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+### Node anti affinity
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+##
+antiAffinity: {}
+
+## Use an alternate scheduler, e.g. "stork".
+## Ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+################################
+### Security Related Configs ###
+################################
+rbac:
+  create: true
+  ## Use a ClusterRole (and ClusterRoleBinding)
+  ## - If set to false - we define a Role and RoleBinding in the defined namespaces ONLY
+  useClusterRole: true
+
+  ## Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to the rolename set here.
+  useExistingRole: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # Annotations to add to the service account
+  annotations: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Force namespace of namespaced resources
+forceNamespace: null


### PR DESCRIPTION
https://helm.sh/docs/howto/chart_releaser_action/

This pushes the helm packages to the gh-pages branch. You can see an example here:
https://github.com/prometheus-community/helm-charts/tree/gh-pages
It also pushes a GitHub release separately, but helps keep the chart release from being tied to GH releases.