### PR TITLE
INT-2263 - Update to use latest required environment variables

### DIFF
--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -3,5 +3,5 @@ name: graph-kubernetes
 description:
   Converts K8s resources into a graph model for ingestion into JupiterOne.
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: '0.4.0'

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -143,7 +143,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: ACCESS_TYPE
-                  value: {{ ternary "cluster" "namespace" .Values.rbac.useClusterRole }} 
+                  value: {{ ternary "cluster" "namespace" .Values.rbac.useClusterRole }}
                 - name: NAMESPACE
                   value: {{ .Release.Namespace }}
                 - name: JUPITERONE_ACCOUNT_ID
@@ -161,7 +161,7 @@ spec:
                     secretKeyRef:
                       name: {{ include "graph-kubernetes.fullname" . }}
                       key: jupiteroneIntegrationInstanceId
-                - name: IS_RUNNING_TEST
+                - name: LOAD_KUBERNETES_CONFIG_FROM_DEFAULT
                   value: 'false'
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}


### PR DESCRIPTION
- Switch from using `IS_RUNNING_TEST` to `LOAD_KUBERNETES_CONFIG_FROM_DEFAULT`
  in the Kubernetes CronJob resource