### PR TITLE
Updates sdk dependencies to allow for base api url to be customizable

### DIFF
--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -3,5 +3,5 @@ name: graph-kubernetes
 description:
   Converts K8s resources into a graph model for ingestion into JupiterOne.
 type: application
-version: 0.9.1
-appVersion: '0.9.1'
+version: 0.9.2
+appVersion: '0.9.2'

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -126,7 +126,7 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ['/kubexit/kubexit', 'yarn']
-              args: ['collect']
+              args: ['execute']
               env:
                 - name: KUBEXIT_NAME
                   value: graph-kubernetes

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -4,7 +4,7 @@
 image:
   repository: jupiterone/graph-kubernetes
   pullPolicy: IfNotPresent
-  tag: "0.9.1"
+  tag: "0.9.2"
 
 cronjob:
   schedule: "*/30 * * * *"


### PR DESCRIPTION
Fixes broken release 0.9.1, that required sdk dependencies to first be updated to allow base api url to be customized.

Maintains backwards compatibility

Updated graph-kubernetes helm chart application dependency to 0.9.2 (updates integration sdk dependencies and updates service account j1 user entity with required "active" field)

Updates the entry docker command to execute (for the cronjob). In graph-kubernetes version 0.9.2, we added an entry command "execute" that makes a call to the integration sdk run command (which performs a jupiterone integration collect and sync) to match integration sdk conventions.

