### PR TITLE
[NO-TICKET] adds support for imagePullSecretse

### DIFF
--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -3,5 +3,5 @@ name: graph-kubernetes
 description:
   Converts K8s resources into a graph model for ingestion into JupiterOne.
 type: application
-version: 0.9.3
+version: 0.9.4
 appVersion: '0.9.2'

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -107,6 +107,10 @@ spec:
     spec:
       template:
         spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: Never
           serviceAccountName: {{ include "graph-kubernetes.serviceAccountName" . }}
           {{- if .Values.securityContext }}

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -6,6 +6,8 @@ image:
   pullPolicy: IfNotPresent
   tag: "0.9.2"
 
+imagePullSecrets: []
+
 cronjob:
   schedule: "*/30 * * * *"
 
@@ -93,7 +95,8 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -95,8 +95,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION
Currently we do not support imagePullSecrets which means users can't self-host in a private repo, or use an authenticated user to bypass rate limiting. This adds support for using imagePullSecrets.
