### PR TITLE
Allow for the use of existing secrets

### DIFF
--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -3,5 +3,5 @@ name: graph-kubernetes
 description:
   Converts K8s resources into a graph model for ingestion into JupiterOne.
 type: application
-version: 0.9.4
+version: 0.9.5
 appVersion: '0.9.2'

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -153,20 +153,20 @@ spec:
                 - name: JUPITERONE_ACCOUNT_ID
                   valueFrom:
                     secretKeyRef:
-                      name: {{ include "graph-kubernetes.fullname" . }}
-                      key: jupiteroneAccountId
+                      name: {{ (tpl .Values.existingSecret.name .) | default (include "graph-kubernetes.fullname" .) }}
+                      key: {{ .Values.existingSecret.jupiteroneAccountIdSecretKey | default "jupiteroneAccountId" }}
                 - name: JUPITERONE_API_KEY
                   valueFrom:
                     secretKeyRef:
-                      name: {{ include "graph-kubernetes.fullname" . }}
-                      key: jupiteroneApiKey
+                      name: {{ (tpl .Values.existingSecret.name .) | default (include "graph-kubernetes.fullname" .) }}
+                      key: {{ .Values.existingSecret.jupiteroneApiKeySecretKey | default "jupiteroneApiKey" }}
                 - name: JUPITERONE_API_BASE_URL
-                  value: {{ template "settings.baseApiUrl" . }}      
+                  value: {{ template "settings.baseApiUrl" . }}
                 - name: INTEGRATION_INSTANCE_ID
                   valueFrom:
                     secretKeyRef:
-                      name: {{ include "graph-kubernetes.fullname" . }}
-                      key: jupiteroneIntegrationInstanceId
+                      name: {{ (tpl .Values.existingSecret.name .) | default (include "graph-kubernetes.fullname" .) }}
+                      key: {{ .Values.existingSecret.jupiteroneIntegrationInstanceIdSecretKey | default "jupiteroneIntegrationInstanceId" }}
                 - name: LOAD_KUBERNETES_CONFIG_FROM_DEFAULT
                   value: 'false'
               resources:

--- a/charts/graph-kubernetes/templates/secret.yaml
+++ b/charts/graph-kubernetes/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if (not .Values.existingSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ data:
   jupiteroneAccountId: {{ default "" .Values.secrets.jupiteroneAccountId | b64enc | quote }}
   jupiteroneApiKey: {{ default "" .Values.secrets.jupiteroneApiKey | b64enc | quote }}
   jupiteroneIntegrationInstanceId: {{ default "" .Values.secrets.jupiteroneIntegrationInstanceId | b64enc | quote }}
+{{- end }}

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -16,6 +16,14 @@ secrets:
   jupiteroneApiKey:
   jupiteroneIntegrationInstanceId:
 
+# Use an existing secret for the jupiterone secrets
+existingSecret:
+  # name of the secret. Can be templated.
+  name: ""
+  jupiteroneAccountIdSecretKey: jupiteroneAccountId
+  jupiteroneApiKeySecretKey: jupiteroneApiKey
+  jupiteroneIntegrationInstanceIdSecretKey: jupiteroneIntegrationInstanceId
+
 settings:
   baseApiUrl: https://api.us.jupiterone.io
 


### PR DESCRIPTION
This is similar to how [the Grafana chart](https://github.com/grafana/helm-charts/blob/0476ba6e13ebb5aea069942961965711ec2e3967/charts/grafana/templates/secret.yaml#L1) approaches allowing [an existing secret ](https://github.com/grafana/helm-charts/blob/0476ba6e13ebb5aea069942961965711ec2e3967/charts/grafana/templates/_pod.tpl#L284-L286) in the namespace to be used (instead of requiring secrets to be provided to the Helm chart to have it create and manage the k8s secret object). 

This allows for the secret objects to be managed with tools like https://github.com/external-secrets/external-secrets/. 

We use [the forked version of this chart](https://github.com/Seqster/JupiterOne-helm-charts/pull/1) internally now with the changes in this PR to source secrets and supply secrets in that manner to the Chart. 