### PR TITLE
INT-11633 - migrate to ghcr

### DIFF
--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -2,6 +2,5 @@ apiVersion: v2
 name: graph-kubernetes
 description: Converts K8s resources into a graph model for ingestion into JupiterOne.
 type: application
-version: 2.4.0
-appVersion: "2.4.0"
-
+version: 2.4.1
+appVersion: "2.4.1"

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -134,8 +134,7 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              command: ['/kubexit/kubexit', 'yarn']
-              args: ['execute']
+              command: ['/kubexit/kubexit', './script/run.sh']
               env:
                 - name: KUBEXIT_NAME
                   value: graph-kubernetes

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -2,9 +2,9 @@
 ########### General ############
 ################################
 image:
-  repository: jupiterone/graph-kubernetes
+  repository: https://ghcr.io/jupiterone/graph-kubernetes
   pullPolicy: IfNotPresent
-  tag: "2.4.0"
+  tag: "2.4.1"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This moves the helm chart to use our new integration image hosted in GHCR. Further it migrates the execution of this job from yarn to pure shell and NodeJS. 