### PR TITLE
Support containerSecurityContext and custom labels

### DIFF
--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: graph-kubernetes
 description: Converts K8s resources into a graph model for ingestion into JupiterOne.
 type: application
-version: 2.4.5
+version: 2.4.6
 appVersion: "2.4.4"

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -103,15 +103,24 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "graph-kubernetes.labels" . | nindent 12 }}
+        {{- include "graph-kubernetes.labels" . | nindent 8 }}
+    {{- with .Values.jobLabels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       template:
+        {{- if or .Values.podAnnotations .Values.podLabels }}
+        metadata:
+        {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.podLabels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+        {{- end }} 
+        {{- end }}
         spec:
-          {{- with .Values.podAnnotations }}
-          metadata:
-            annotations:
-              {{- toYaml . | nindent 14 }}
-          {{- end }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
@@ -127,6 +136,10 @@ spec:
               image: "{{ .Values.kubexit.repository }}:{{ .Values.kubexit.tag }}"
               command: ['cp']
               args: ['/bin/kubexit', '/kubexit/kubexit']
+              {{- if .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              {{- end }}
               resources:
                  {{- toYaml .Values.kubexit.resources | nindent 16 }}
               volumeMounts:
@@ -175,6 +188,10 @@ spec:
                       key: {{ .Values.existingSecret.jupiteroneIntegrationInstanceIdSecretKey | default "jupiteroneIntegrationInstanceId" }}
                 - name: LOAD_KUBERNETES_CONFIG_FROM_DEFAULT
                   value: 'false'
+              {{- if .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              {{- end }}
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
               volumeMounts:
@@ -204,6 +221,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+              {{- if .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              {{- end }}
               resources:
                 {{- toYaml .Values.otelCollector.resources | nindent 16 }}
               volumeMounts:
@@ -237,6 +258,10 @@ spec:
                   value: otel-collector       
                 - name: KUBEXIT_DEATH_DEPS
                   value: graph-kubernetes
+              {{- if .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              {{- end }}
               resources:
                 {{- toYaml .Values.fluentBit.resources | nindent 16 }}
               volumeMounts:

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -130,7 +130,7 @@ spec:
           {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{ end }}
+          {{- end }}
           initContainers:
             - name: kubexit
               image: "{{ .Values.kubexit.repository }}:{{ .Values.kubexit.tag }}"

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -118,8 +118,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -127,8 +126,7 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-containerSecurityContext:
-  {}
+containerSecurityContext: {}
   # capabilities:
   #   drop:
   #   - ALL

--- a/charts/graph-kubernetes/values.yaml
+++ b/charts/graph-kubernetes/values.yaml
@@ -58,6 +58,16 @@ jobAnnotations: {}
 ##
 podAnnotations: {}
 
+## Job labels
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+jobLabels: {}
+
+## Pod labels
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
 ## Node labels
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
@@ -109,6 +119,15 @@ serviceAccount:
   annotations: {}
 
 securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+containerSecurityContext:
   {}
   # capabilities:
   #   drop:


### PR DESCRIPTION
**Context**
We make use of Gatekeeper in our Kubernetes clusters and have several policy enforcements there.
Some of the policies are blocking the deployment of your graph-kubernetes helm chart which are:
- Missing required custom labels attached to the containers
- Containers are not dropping all capabilities

After checking your helm-chart I propose the following changes via this PR:

- Fix: The podAnnotations are in the wrong place as you can see [here](https://github.com/JupiterOne/helm-charts/blob/main/charts/graph-kubernetes/templates/cronjob.yaml#L110-L114). According to the [docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podtemplatespec-v1-core) the metadata needs to be in the spec.template section instead of spec.template.spec.
- Feature: Adds support for custom labels
- Feature: Adds support for containerSecurityContext