### PR TITLE
Fix otel config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Chart dependencies
 /charts/*/charts
+
+values.yaml

--- a/charts/graph-kubernetes/templates/cronjob.yaml
+++ b/charts/graph-kubernetes/templates/cronjob.yaml
@@ -66,29 +66,25 @@ data:
         check_interval: 5s
 
     exporters:
-      logging:
-        loglevel: debug
+      debug:
+        verbosity: detailed
         sampling_initial: 5
         sampling_thereafter: 200
-
-    extensions:
-      memory_ballast:
-        size_mib: 165
 
     service:
       pipelines:
         logs:
           receivers: [fluentforward]
           processors: [memory_limiter, batch]
-          exporters: [logging]
+          exporters: [debug]
         metrics:
           receivers: [hostmetrics]
           processors: [memory_limiter, batch]
-          exporters: [logging]
+          exporters: [debug]
         traces:
           receivers: [otlp]
           processors: [memory_limiter, batch]
-          exporters: [logging]
+          exporters: [debug]
 ---
 apiVersion: {{ template "cronjob.apiVersion" . }}
 kind: CronJob


### PR DESCRIPTION
For context, customer mentioned they are getting this error: 

```
collector server run finished with error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
error decoding 'exporters': the logging exporter has been deprecated, use the debug exporter instead
error decoding 'extensions': unknown type: "memory_ballast" for id: "memory_ballast" (valid values: [awsproxy zipkin_encoding jaeger_encoding googleclientauth health_check docker_observer host_observer opamp db_storage redis_storage basicauth bearertokenauth jaegerremotesampling oidc ack json_log_encoding http_forwarder sumologic oauth2client headers_setter ecs_observer sigv4auth file_storage zpages asapclient otlp_encoding ecs_task_observer k8s_observer pprof])
```

They fixed this themselves and want the config updated here:

"Once I removed the extensions.memory_ballast option completely and refactord the otel-agent config to look like that, it started to work"