### PR TITLE
Remove Kubernetes integration sidecars to simplify integration - Release 2.4.17

### DIFF
--- a/charts/graph-kubernetes/Chart.yaml
+++ b/charts/graph-kubernetes/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: graph-kubernetes
 description: Converts K8s resources into a graph model for ingestion into JupiterOne.
 type: application
-version: 2.4.16
-appVersion: "2.4.16"
+version: 2.4.17
+appVersion: "2.4.17"


### PR DESCRIPTION
Remove Kubernetes integration sidecars to simplify integration

Bumps helm chart version to: 2.4.17

Related pr: https://github.com/JupiterOne/helm-charts/pull/49