### PR TITLE
Allows forcing image tag on helm install

### DIFF
--- a/charts/jupiterone-integration-operator/Chart.yaml
+++ b/charts/jupiterone-integration-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jupiterone-integration-operator
 description: A Helm chart for the JupiterOne Integration Operator
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "v0.0.13"

--- a/charts/jupiterone-integration-operator/templates/manager/manager.yaml
+++ b/charts/jupiterone-integration-operator/templates/manager/manager.yaml
@@ -33,7 +33,7 @@ spec:
             {{- end }}
           command:
             - /manager
-          image: {{ .Values.controllerManager.container.image.repository }}:{{ .Chart.AppVersion }}
+          image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag | default .Chart.AppVersion }}
           {{- if .Values.controllerManager.container.env }}
           env:
             {{- range $key, $value := .Values.controllerManager.container.env }}

--- a/charts/jupiterone-integration-operator/values.yaml
+++ b/charts/jupiterone-integration-operator/values.yaml
@@ -4,6 +4,7 @@ controllerManager:
   container:
     image:
       repository: ghcr.io/jupiterone/jupiterone-integration-operator
+      tag: "" # Use the appVersion from the chart unless overridden by command line
     args:
       - "--leader-elect"
       - "--metrics-bind-address=:8443"
@@ -73,7 +74,7 @@ integration:
 runner:
   # Specifies whether to create the runner resources
   create: false
-  # The name of the runner. 
+  # The name of the runner.
   name: operator-1
   # The namespace where the runner will be deployed
   namespace: jupiterone
@@ -81,7 +82,7 @@ runner:
   collectorID: <collector-id>
   # The JupiterOne account ID, found in the JupiterOne UI under Settings > Account Management
   accountID: <account-id>
-  # The auth token for the runner, 
+  # The auth token for the runner,
   authToken: <auth-token>
   # The interval in seconds for syncing data with JupiterOne
   syncIntervalSeconds: 30


### PR DESCRIPTION
You can now set the tag of the runner for example `--set controllerManager.container.image.tag=v1.0.0`