### PR TITLE
chore: bump chart version to 1.2.0 and appVersion to v0.1.0

### DIFF
--- a/charts/jupiterone-integration-operator/Chart.yaml
+++ b/charts/jupiterone-integration-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jupiterone-integration-operator
 description: JupiterOne Integration Operator for running integrations in Kubernetes
 type: application
-version: 1.1.19
-appVersion: "v0.0.37"
+version: 1.2.0
+appVersion: "v0.1.0"


### PR DESCRIPTION
## Summary
- Bumps chart `version` from `1.1.19` to `1.2.0` to reflect new private registry features
- Bumps `appVersion` from `v0.0.37` to `v0.1.0` to match the [operator container image tag](https://github.com/jupiterone/jupiterone-integration-operator/pkgs/container/jupiterone-integration-operator/757004969?tag=v0.1.0)

## Test plan
- [ ] Verify `helm template` renders correctly with new version
- [ ] Confirm chart installs successfully with updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)