### PR TITLE
chore: bump integration operator to v0.1.1

### DIFF
--- a/charts/jupiterone-integration-operator/Chart.yaml
+++ b/charts/jupiterone-integration-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jupiterone-integration-operator
 description: JupiterOne Integration Operator for running integrations in Kubernetes
 type: application
-version: 1.2.0
-appVersion: "v0.1.0"
+version: 1.2.1
+appVersion: "v0.1.1"


### PR DESCRIPTION
## Summary

Bump the integration operator appVersion to `v0.1.1` and chart version to `1.2.1`.

## What's in v0.1.1

Cosign signature verification now falls back to `ghcr.io` when a private registry is configured but doesn't mirror cosign signature artifacts. Previously this caused verification failures for customers using `imageRegistry` without also setting `disableImageSignatureCheck: true`.

- Operator PR: https://github.com/JupiterOne/jupiterone-integration-operator/pull/42
- Docs PR: https://github.com/JupiterOne/docs-v2/pull/662

## Changes

| File | Change |
|------|--------|
| `Chart.yaml` | `version: 1.2.0` → `1.2.1`, `appVersion: v0.1.0` → `v0.1.1` |

Refs: TD-8175, TD-8173