### PR TITLE
feat: add jobResources helm value, bump to operator v0.2.0 (TD-8247)

### DIFF
--- a/charts/jupiterone-integration-operator/Chart.yaml
+++ b/charts/jupiterone-integration-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jupiterone-integration-operator
 description: JupiterOne Integration Operator for running integrations in Kubernetes
 type: application
-version: 1.2.1
-appVersion: "v0.1.1"
+version: 1.3.0
+appVersion: "v0.2.0"

--- a/charts/jupiterone-integration-operator/README.md
+++ b/charts/jupiterone-integration-operator/README.md
@@ -54,6 +54,7 @@ Refer to the [values.yaml](./values.yaml) for all available configuration option
 | `controllerManager.imageRegistry` | Image registry override for private registry environments. When set, integration job images are pulled from this registry instead of `ghcr.io`. | `""` |
 | `controllerManager.imagePullSecrets` | Secrets for pulling images from private registries. Applied to both the operator Deployment and propagated to spawned integration job pods. | `[]` |
 | `controllerManager.disableImageSignatureCheck` | Disable cosign image signature verification for integration job images. Set to `true` when using registries that don't mirror ghcr.io cosign signatures. | `false` |
+| `controllerManager.jobResources` | Resource requests and limits applied to integration job containers. Configure to comply with cluster resource policies (e.g. Kyverno, OPA/Gatekeeper). | `{}` |
 
 ### Private Registry Example
 
@@ -76,6 +77,21 @@ helm install integration-operator jupiterone/jupiterone-integration-operator \
 ```
 
 > **Note:** `disableImageSignatureCheck` is independent of `imageRegistry`. Cosign verification may work through registry proxies since it resolves signatures against the original source. Only disable it if verification fails in your environment.
+
+### Job Resources Example
+
+If your cluster enforces resource policies (e.g. Kyverno `require-requests-limits`), configure resource requirements for integration job containers:
+
+```yaml
+controllerManager:
+  jobResources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+```
 
 ## Usage
 

--- a/charts/jupiterone-integration-operator/templates/crds/integrations.jupiterone.io_integrationinstancejobs.yaml
+++ b/charts/jupiterone-integration-operator/templates/crds/integrations.jupiterone.io_integrationinstancejobs.yaml
@@ -18,6 +18,10 @@ spec:
       jsonPath: .status.imageVerified
       name: Verified
       type: string
+    - description: Indicates if the Kubernetes Job was created
+      jsonPath: .status.jobCreated
+      name: JobCreated
+      type: string
     - description: Age of the resource
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -87,6 +91,16 @@ spec:
                 description: |-
                   ImageVerified indicates the status of the cosign image verification step.
                   It can be one of the following values: PENDING, SUCCESS, FAILED.
+                type: string
+              jobCreated:
+                description: |-
+                  JobCreated indicates whether the Kubernetes Job was successfully created.
+                  Values: PENDING, SUCCESS, FAILED.
+                type: string
+              jobCreationError:
+                description: |-
+                  JobCreationError contains the error message if Job creation failed.
+                  Empty when JobCreated is SUCCESS or PENDING. Truncated to 1024 characters.
                 type: string
             type: object
         type: object

--- a/charts/jupiterone-integration-operator/templates/manager/manager.yaml
+++ b/charts/jupiterone-integration-operator/templates/manager/manager.yaml
@@ -57,6 +57,10 @@ spec:
             - name: IMAGE_PULL_SECRETS
               value: {{ . | toJson | quote }}
             {{- end }}
+            {{- with .Values.controllerManager.jobResources }}
+            - name: JOB_RESOURCES
+              value: {{ . | toJson | quote }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.controllerManager.container.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/jupiterone-integration-operator/values.yaml
+++ b/charts/jupiterone-integration-operator/values.yaml
@@ -55,6 +55,18 @@ controllerManager:
   #   imagePullSecrets:
   #     - name: my-registry-secret
   imagePullSecrets: []
+  # Resource requests and limits applied to integration job containers.
+  # Configure these to comply with cluster resource policies (e.g. Kyverno, OPA/Gatekeeper).
+  # When empty, no resource requirements are set on job containers.
+  # Example:
+  #   jobResources:
+  #     requests:
+  #       cpu: 100m
+  #       memory: 256Mi
+  #     limits:
+  #       cpu: "1"
+  #       memory: 1Gi
+  jobResources: {}
 
 # [RBAC]: To enable RBAC (Permissions) configurations
 rbac:


### PR DESCRIPTION
## Summary

- Adds `controllerManager.jobResources` value — configures resource requests/limits on integration job containers via `JOB_RESOURCES` env var
- Bumps chart version `1.2.1` -> `1.3.0`, appVersion `v0.1.1` -> `v0.2.0`
- Backwards compatible: when `jobResources` is empty (default), no env var is injected

## Jira

[TD-8247](https://jupiterone.atlassian.net/browse/TD-8247)

## Related PRs

- Operator: jupiterone-integration-operator#43 (merged)
- Docs: docs-v2#682

## Test plan

- [x] `helm template` with default values — no `JOB_RESOURCES` env var present
- [x] `helm template` with `jobResources` set — correct JSON-encoded `JOB_RESOURCES` env var
- [x] Image tag resolves to `v0.2.0` via appVersion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TD-8247]: https://jupiterone.atlassian.net/browse/TD-8247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ